### PR TITLE
90%: Multiple failed queues

### DIFF
--- a/bin/resque
+++ b/bin/resque
@@ -32,6 +32,9 @@ if(empty($QUEUE)) {
 
 $RESQUE_FAILURE_BACKEND = getenv('RESQUE_FAILURE_BACKEND');
 Resque_Failure::setBackend($RESQUE_FAILURE_BACKEND);
+if(!empty($RESQUE_FAILURE_BACKEND)) {
+    Resque::redis()->sadd('failed_queues', 'failed');
+}
 
 /**
  * REDIS_BACKEND can have simple 'host:port' format or use a DSN-style format like this:

--- a/bin/resque
+++ b/bin/resque
@@ -30,6 +30,9 @@ if(empty($QUEUE)) {
     die("Set QUEUE env var containing the list of queues to work.\n");
 }
 
+$RESQUE_FAILURE_BACKEND = getenv('RESQUE_FAILURE_BACKEND');
+Resque_Failure::setBackend($RESQUE_FAILURE_BACKEND);
+
 /**
  * REDIS_BACKEND can have simple 'host:port' format or use a DSN-style format like this:
  * - redis://user:pass@host:port

--- a/lib/Resque/Failure/Redis.php
+++ b/lib/Resque/Failure/Redis.php
@@ -29,6 +29,7 @@ class Resque_Failure_Redis implements Resque_Failure_Interface
 		$data->queue = $queue;
 		$data = json_encode($data);
 		Resque::redis()->rpush('failed', $data);
+        Resque_Stat::incr('failed');
 	}
 }
 ?>

--- a/lib/Resque/Failure/RedisMultipleQueues.php
+++ b/lib/Resque/Failure/RedisMultipleQueues.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Redis backend for storing failed Resque jobs.
+ *
+ * @package		Resque/Failure
+ * @author		Omar Qureshi <oq@talis.com>
+ * @license		http://www.opensource.org/licenses/mit-license.php
+ */
+
+class Resque_Failure_RedisMultipleQueues implements Resque_Failure_Interface
+{
+	/**
+	 * Initialize a failed job class and save it (where appropriate).
+	 *
+	 * @param object $payload Object containing details of the failed job.
+	 * @param object $exception Instance of the exception that was thrown by the failed job.
+	 * @param object $worker Instance of Resque_Worker that received the job.
+	 * @param string $queue The name of the queue the job was fetched from.
+	 */
+	public function __construct($payload, $exception, $worker, $queue)
+	{
+		$data = new stdClass;
+		$data->failed_at = strftime('%a %b %d %H:%M:%S %Z %Y');
+		$data->payload = $payload;
+		$data->exception = get_class($exception);
+		$data->error = $exception->getMessage();
+		$data->backtrace = explode("\n", $exception->getTraceAsString());
+		$data->worker = (string)$worker;
+		$data->queue = $queue;
+		$data = json_encode($data);
+		Resque::redis()->rpush($queue . '_failed', $data);
+	}
+}
+?>

--- a/lib/Resque/Failure/RedisMultipleQueues.php
+++ b/lib/Resque/Failure/RedisMultipleQueues.php
@@ -29,6 +29,7 @@ class Resque_Failure_RedisMultipleQueues implements Resque_Failure_Interface
 		$data->queue = $queue;
 		$data = json_encode($data);
 		Resque::redis()->rpush($queue . '_failed', $data);
+		Resque::redis()->sadd('failed_queues', $queue . '_failed');
 	}
 }
 ?>

--- a/lib/Resque/Failure/RedisMultipleQueues.php
+++ b/lib/Resque/Failure/RedisMultipleQueues.php
@@ -30,6 +30,7 @@ class Resque_Failure_RedisMultipleQueues implements Resque_Failure_Interface
 		$data = json_encode($data);
 		Resque::redis()->rpush($queue . '_failed', $data);
 		Resque::redis()->sadd('failed_queues', $queue . '_failed');
+        Resque_Stat::incr($queue . '_failed');
 	}
 }
 ?>

--- a/lib/Resque/Job.php
+++ b/lib/Resque/Job.php
@@ -233,8 +233,9 @@ class Resque_Job
 
         if (Resque_Failure::getBackend() == 'Resque_Failure_RedisMultipleQueues') {
             Resque_Stat::incr($this->queue . '_failed');
+        } else {
+            Resque_Stat::incr('failed');
         }
-		Resque_Stat::incr('failed');
 		Resque_Stat::incr('failed:' . $this->worker);
 	}
 

--- a/lib/Resque/Job.php
+++ b/lib/Resque/Job.php
@@ -230,6 +230,10 @@ class Resque_Job
 			$this->worker,
 			$this->queue
 		);
+
+        if (Resque_Failure::getBackend() == 'Resque_Failure_RedisMultipleQueues') {
+            Resque_Stat::incr($this->queue . '_failed');
+        }
 		Resque_Stat::incr('failed');
 		Resque_Stat::incr('failed:' . $this->worker);
 	}

--- a/lib/Resque/Job.php
+++ b/lib/Resque/Job.php
@@ -230,13 +230,7 @@ class Resque_Job
 			$this->worker,
 			$this->queue
 		);
-
-        if (Resque_Failure::getBackend() == 'Resque_Failure_RedisMultipleQueues') {
-            Resque_Stat::incr($this->queue . '_failed');
-        } else {
-            Resque_Stat::incr('failed');
-        }
-		Resque_Stat::incr('failed:' . $this->worker);
+        Resque_Stat::incr('failed:' . $this->worker);
 	}
 
 	/**

--- a/test/Resque/Tests/JobTest.php
+++ b/test/Resque/Tests/JobTest.php
@@ -180,4 +180,30 @@ class Resque_Tests_JobTest extends Resque_Tests_TestCase
         Resque_Redis::prefix('resque');
         $this->assertEquals(Resque::size($queue), 0);        
 	}
+
+	public function testMultipleFailedQueues()
+	{
+		Resque_Failure::setBackend('Resque_Failure_RedisMultipleQueues');
+
+		$payload = array(
+			'class' => 'Failing_Job',
+			'args' => null
+		);
+		$job = new Resque_Job('jobs', $payload);
+		$job->worker = $this->worker;
+		$this->worker->perform($job);
+
+		$payload = array(
+			'class' => 'Failing_Job',
+			'args' => null
+		);
+		$job = new Resque_Job('other_jobs', $payload);
+		$job->worker = $this->worker;
+		$this->worker->perform($job);
+
+		$this->assertEquals(1, Resque_Stat::get('jobs_failed'));
+		$this->assertEquals(1, Resque_Stat::get('other_jobs_failed'));
+		$this->assertEquals(2, Resque_Stat::get('failed'));
+		$this->assertEquals(2, Resque_Stat::get('failed:'.$this->worker));
+	}
 }

--- a/test/Resque/Tests/JobTest.php
+++ b/test/Resque/Tests/JobTest.php
@@ -192,18 +192,12 @@ class Resque_Tests_JobTest extends Resque_Tests_TestCase
 		$job = new Resque_Job('jobs', $payload);
 		$job->worker = $this->worker;
 		$this->worker->perform($job);
-
-		$payload = array(
-			'class' => 'Failing_Job',
-			'args' => null
-		);
 		$job = new Resque_Job('other_jobs', $payload);
 		$job->worker = $this->worker;
 		$this->worker->perform($job);
 
 		$this->assertEquals(1, Resque_Stat::get('jobs_failed'));
 		$this->assertEquals(1, Resque_Stat::get('other_jobs_failed'));
-		$this->assertEquals(2, Resque_Stat::get('failed'));
 		$this->assertEquals(2, Resque_Stat::get('failed:'.$this->worker));
 		$this->assertEquals(1, count(Resque::redis()->lrange('jobs_failed', 0, -1)));
 		$this->assertEquals(1, count(Resque::redis()->lrange('other_jobs_failed', 0, -1)));

--- a/test/Resque/Tests/JobTest.php
+++ b/test/Resque/Tests/JobTest.php
@@ -205,5 +205,9 @@ class Resque_Tests_JobTest extends Resque_Tests_TestCase
 		$this->assertEquals(1, Resque_Stat::get('other_jobs_failed'));
 		$this->assertEquals(2, Resque_Stat::get('failed'));
 		$this->assertEquals(2, Resque_Stat::get('failed:'.$this->worker));
+		$this->assertEquals(1, count(Resque::redis()->lrange('jobs_failed', 0, -1)));
+		$this->assertEquals(1, count(Resque::redis()->lrange('other_jobs_failed', 0, -1)));
+		$this->assertEquals(1, Resque::redis()->sismember('failed_queues', 'jobs_failed'));
+		$this->assertEquals(1, Resque::redis()->sismember('failed_queues', 'other_jobs_failed'));
 	}
 }

--- a/test/Resque/Tests/TestCase.php
+++ b/test/Resque/Tests/TestCase.php
@@ -19,5 +19,6 @@ class Resque_Tests_TestCase extends PHPUnit_Framework_TestCase
 
 		// Flush redis
 		$this->redis->flushAll();
+        Resque_Failure::setBackend(null);
 	}
 }


### PR DESCRIPTION
Allow you to set the failure backend to Resque_Failure_RedisMultipleQueues

Upon doing so the following happens:
- Any failed job gets put on "${queue}_failed"
- Increments "${queue}_failed" count
- Increments worker failed count
- Increments failed count

No idea if this corresponds to what resque_web expects, will test some more
