### PR TITLE
Apply change for declare ticks

### DIFF
--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -1,4 +1,6 @@
 <?php
+declare(ticks = 1);
+
 /**
  * Resque worker that handles checking queues for jobs, fetching them
  * off the queues, running them and handling the result.
@@ -349,7 +351,6 @@ class Resque_Worker
 			return;
 		}
 
-		declare(ticks = 1);
 		pcntl_signal(SIGTERM, array($this, 'shutDownNow'));
 		pcntl_signal(SIGINT, array($this, 'shutDownNow'));
 		pcntl_signal(SIGQUIT, array($this, 'shutdown'));


### PR DESCRIPTION
See https://github.com/chrisboulton/php-resque/pull/296 for the change in upstream.

Before the change, workers would take until their timeout in order to restart, with this change:
```
$ date;ls tadc*|cut -d '.' -f 1|xargs -I {} sudo service {} restart;date
Tue Jun 25 12:57:50 UTC 2019
tadc-bulkimport-store-images-worker stop/waiting
tadc-bulkimport-store-images-worker start/running, process 1590
tadc-bulkimport-worker stop/waiting
tadc-bulkimport-worker start/running, process 1603
tadc-cla-check-permissions-report-worker stop/waiting
tadc-cla-check-permissions-report-worker start/running, process 1616
tadc-cla-munge-worker stop/waiting
tadc-cla-munge-worker start/running, process 1629
tadc-cla-schedule-reports-worker stop/waiting
tadc-cla-schedule-reports-worker start/running, process 1646
tadc-cla-tptp-rollover-check-worker-2 stop/waiting
tadc-cla-tptp-rollover-check-worker-2 start/running, process 1659
tadc-cla-tptp-rollover-check-worker-3 stop/waiting
tadc-cla-tptp-rollover-check-worker-3 start/running, process 1672
tadc-cla-tptp-rollover-check-worker stop/waiting
tadc-cla-tptp-rollover-check-worker start/running, process 1685
tadc-cla-tptp-rollover-csv-report-worker stop/waiting
tadc-cla-tptp-rollover-csv-report-worker start/running, process 1698
tadc-complete-rollover-worker stop/waiting
tadc-complete-rollover-worker start/running, process 1713
tadc-copy-limits-check-report-worker stop/waiting
tadc-copy-limits-check-report-worker start/running, process 1729
tadc-dcs-integration-worker stop/waiting
tadc-dcs-integration-worker start/running, process 1747
tadc-dcs-synchronisation-worker stop/waiting
tadc-dcs-synchronisation-worker start/running, process 1763
tadc-dk-export-worker stop/waiting
tadc-dk-export-worker start/running, process 1780
tadc-incidental-artwork-export-worker stop/waiting
tadc-incidental-artwork-export-worker start/running, process 1795
tadc-packer-worker stop/waiting
tadc-packer-worker start/running, process 1814
tadc-process-request-worker stop/waiting
tadc-process-request-worker start/running, process 1832
tadc-report-generator-worker stop/waiting
tadc-report-generator-worker start/running, process 1848
tadc-rollover-preclearance-worker stop/waiting
tadc-rollover-preclearance-worker start/running, process 1865
tadc-rollover-store-images-worker stop/waiting
tadc-rollover-store-images-worker start/running, process 1882
tadc-send-email-worker stop/waiting
tadc-send-email-worker start/running, process 1899
tadc-store-images-worker stop/waiting
tadc-store-images-worker start/running, process 1917
tadc-worldcat-works-worker stop/waiting
tadc-worldcat-works-worker start/running, process 1930
Tue Jun 25 12:57:53 UTC 2019
```

Workers all coming through and doing work as expected.